### PR TITLE
Ci/eval tests

### DIFF
--- a/.github/workflows/nix_eval_tests.yml
+++ b/.github/workflows/nix_eval_tests.yml
@@ -33,12 +33,3 @@ jobs:
             nix build ".#checks.x86_64-linux.$check" --print-build-logs
             echo "::endgroup::"
           done
-
-      - name: Evaluate all hosts
-        run: |
-          hosts=$(nix eval .#nixosConfigurations --apply 'builtins.attrNames' --json)
-          for host in $(echo "$hosts" | jq -r '.[]'); do
-            echo "::group::Evaluating $host"
-            nix eval ".#nixosConfigurations.$host.config.system.build.toplevel" --show-trace
-            echo "::endgroup::"
-          done

--- a/.github/workflows/nix_eval_tests.yml
+++ b/.github/workflows/nix_eval_tests.yml
@@ -1,0 +1,44 @@
+name: Nix Eval Tests
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref }}
+  cancel-in-progress: true
+
+jobs:
+  eval-tests:
+    name: Eval Tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Install Nix
+        uses: DeterminateSystems/nix-installer-action@v22
+
+      - name: Cache Nix store
+        uses: DeterminateSystems/magic-nix-cache-action@main
+
+      - name: Run eval tests
+        run: |
+          checks=$(nix eval .#checks.x86_64-linux --apply 'builtins.attrNames' --json)
+          for check in $(echo "$checks" | jq -r '.[] | select(startswith("eval-"))'); do
+            echo "::group::Running $check"
+            nix build ".#checks.x86_64-linux.$check" --print-build-logs
+            echo "::endgroup::"
+          done
+
+      - name: Evaluate all hosts
+        run: |
+          hosts=$(nix eval .#nixosConfigurations --apply 'builtins.attrNames' --json)
+          for host in $(echo "$hosts" | jq -r '.[]'); do
+            echo "::group::Evaluating $host"
+            nix eval ".#nixosConfigurations.$host.config.system.build.toplevel" --show-trace
+            echo "::endgroup::"
+          done


### PR DESCRIPTION
## Summary

Add GitHub Actions workflow to run eval tests on pull requests, verifying shared module configuration correctness.

## What Changed

- Add `.github/workflows/nix_eval_tests.yml` workflow that dynamically discovers and runs all `eval-*` flake checks
- Uses `::group::` for organized output per test in CI logs

## Why

- **Problem:** Eval tests were added to the flake but not integrated into CI — they would only run if someone manually executed `nix flake check`.
- **Approach:** Dedicated workflow that filters checks starting with `eval-` and runs them with grouped output for clear failure identification.

## Scope

- [ ] Flake (inputs, outputs, specialArgs)
- [ ] Host: `starkiller`
- [ ] Host: `vader`
- [ ] Shared Module: `core/`
- [ ] Shared Module: `graphical/`
- [ ] Shared Module: `hardware/`
- [ ] Shared Module: `home/`
- [ ] Shared Module: `impermanence/`
- [ ] Disk Layout (Disko)
- [x] CI / GitHub Actions
- [ ] Documentation
- [ ] Security / Secrets

## Testing

- [ ] Not tested yet
- [x] `nix flake check` passes
- [ ] Built locally with `nixos-rebuild build --flake .#<hostname>`
- [ ] Deployed with `nixos-rebuild switch --flake .#<hostname>`
- [ ] NixOS VM test added or updated
- [ ] Tested on `starkiller`
- [ ] Tested on `vader`

## Checklist

- [x] No secrets or password hashes in this PR
- [x] No proprietary font files added (DIN Next must stay in `fonts/din-next/`)
- [x] `system.stateVersion` was **not** modified
- [x] Changes are host-agnostic or overrides are in the correct `hosts/<hostname>/`